### PR TITLE
Dev

### DIFF
--- a/BackgroundServices/QueueProcessor.cs
+++ b/BackgroundServices/QueueProcessor.cs
@@ -72,7 +72,7 @@ namespace AxarDB.BackgroundServices
             
             DateTime startTime = DateTime.UtcNow;
             
-            AxarDB.Logging.Logger.LogDebug($"[Queue] Executing Job {jobId}...");
+            AxarDB.Logging.Logger.LogDebug($"[Queue] Executing Job {jobId}");
 
             bool success = false;
             string? error = null;
@@ -107,7 +107,7 @@ namespace AxarDB.BackgroundServices
                 // So it MUST be a Dictionary<string, object>.
                 // I will cast parameters to Dictionary<string, object>.
                 
-                Dictionary<string, object>? scriptParams = null;
+                System.Collections.Generic.IDictionary<string, object>? scriptParams = null;
                 
                 if (parameters is Dictionary<string, object> dictParams)
                 {
@@ -115,24 +115,17 @@ namespace AxarDB.BackgroundServices
                 }
                 else if (parameters is System.Text.Json.JsonElement je && je.ValueKind == System.Text.Json.JsonValueKind.Object)
                 {
-                   // Conversion might be needed if deserialized as JsonElement
-                   // But AxarDB storage usually keeps it as Dict or primitives if using proper converters.
-                   // Let's rely on standard cast or conversion utility if needed.
-                   // For now, assume it's stored compatible or convert.
                    try {
                        var json = System.Text.Json.JsonSerializer.Serialize(parameters);
-                       scriptParams = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(json);
+                       scriptParams = AxarDB.Helpers.ScriptUtils.SafeDeserializeJson(json) as System.Collections.Generic.IDictionary<string, object>;
                    } catch {}
                 }
                 else if (parameters != null)
                 {
-                     // Try best effort conversion
                      try {
                          var json = System.Text.Json.JsonSerializer.Serialize(parameters);
-                         scriptParams = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(json);
+                         scriptParams = AxarDB.Helpers.ScriptUtils.SafeDeserializeJson(json) as System.Collections.Generic.IDictionary<string, object>;
                      } catch {
-                         // Fallback: If array, maybe mapped to @0, @1?
-                         // For now let's enforce Object for named params as per existing Engine
                      }
                 }
 

--- a/Bridges/AxarDBBridge.cs
+++ b/Bridges/AxarDBBridge.cs
@@ -20,8 +20,13 @@ namespace AxarDB.Bridges
         {
             // db.users -> returns CollectionBridge for "users"
             var collection = _dbEngine.GetCollection(binder.Name);
-            result = new CollectionBridge(collection, _jintEngine, _cancellationToken);
+            result = new CollectionBridge(_dbEngine, collection, _jintEngine, _cancellationToken);
             return true;
+        }
+
+        public void deleteCollection(string name)
+        {
+            _dbEngine.DeleteCollection(name);
         }
 
         public AliasWrapper alias(object source, string name) => new AliasWrapper(source, name);

--- a/Bridges/CollectionBridge.cs
+++ b/Bridges/CollectionBridge.cs
@@ -7,15 +7,22 @@ namespace AxarDB.Bridges
 {
     public class CollectionBridge
     {
+        private readonly DatabaseEngine _dbEngine;
         public readonly Collection _collection;
         private readonly Engine? _engine;
         private readonly CancellationToken _cancellationToken;
 
-        public CollectionBridge(Collection collection, Engine? engine = null, CancellationToken cancellationToken = default)
+        public CollectionBridge(DatabaseEngine dbEngine, Collection collection, Engine? engine = null, CancellationToken cancellationToken = default)
         {
+            _dbEngine = dbEngine;
             _collection = collection;
             _engine = engine;
             _cancellationToken = cancellationToken;
+        }
+
+        public void delete()
+        {
+            _dbEngine.DeleteCollection(_collection.Name);
         }
 
         public void reload()

--- a/DatabaseEngine.cs
+++ b/DatabaseEngine.cs
@@ -85,7 +85,7 @@ namespace AxarDB
                 
                 object? responseData;
                 try {
-                     responseData = System.Text.Json.JsonSerializer.Deserialize<object>(responseString);
+                     responseData = AxarDB.Helpers.ScriptUtils.SafeDeserializeJson(responseString);
                 } catch {
                      responseData = responseString;
                 }
@@ -155,7 +155,7 @@ namespace AxarDB
                 if (parameters != null)
                 {
                      var json = System.Text.Json.JsonSerializer.Serialize(parameters);
-                     var dict = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(json);
+                     var dict = AxarDB.Helpers.ScriptUtils.SafeDeserializeJson(json) as System.Collections.Generic.IDictionary<string, object>;
                      if (dict != null)
                      {
                          foreach(var kvp in dict)
@@ -205,7 +205,7 @@ namespace AxarDB
                 if (parameters != null)
                 {
                      var json = System.Text.Json.JsonSerializer.Serialize(parameters);
-                     var dict = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(json);
+                     var dict = AxarDB.Helpers.ScriptUtils.SafeDeserializeJson(json) as System.Collections.Generic.IDictionary<string, object>;
                      if (dict != null)
                      {
                          foreach(var kvp in dict)
@@ -401,10 +401,10 @@ namespace AxarDB
             return _collections.GetOrAdd(name, n => new Collection(n, _storage, _sharedCache));
         }
 
-        public object? ExecuteScript(string script, Dictionary<string, object>? parameters = null, ScriptContext? context = null, CancellationToken cancellationToken = default)
+        public object? ExecuteScript(string script, System.Collections.Generic.IDictionary<string, object>? parameters = null, ScriptContext? context = null, CancellationToken cancellationToken = default)
         {
             var ctx = context ?? ScriptContext.Default; 
-            AxarDB.Logging.Logger.LogDebug($"[Engine] Executing script (Length: {script.Length})...");
+            AxarDB.Logging.Logger.LogDebug($"[Engine] Executing script:\n{script}");
             // ---------------------------------------------------------
             // VAULTS FEATURE INITIALIZATION
             // ---------------------------------------------------------
@@ -468,8 +468,8 @@ namespace AxarDB
                  options.TimeoutInterval(TimeSpan.FromMinutes(10)); // Default timeout
             });
 
-            // Expose console.log for CLI scripts
-            engine.SetValue("console", new { log = new Action<object>(o => Console.WriteLine(FormatLog(o))) });
+            // Expose console.log for CLI scripts and debugging
+            engine.SetValue("console", new { log = new Action<object>(o => AxarDB.Logging.Logger.LogDebug(FormatLog(o))) });
 
             // Expose 'db'
             var dbBridge = new AxarDBBridge(this, engine, cancellationToken);
@@ -527,7 +527,7 @@ namespace AxarDB
 
         public bool Authenticate(string username, string password)
         {
-            AxarDB.Logging.Logger.LogDebug($"[Auth] Authenticating user '{username}'...");
+            AxarDB.Logging.Logger.LogDebug($"[Auth] Authenticating user '{username}'");
             var sysusers = GetCollection("sysusers");
             
             // Try matching plain password first
@@ -600,7 +600,7 @@ namespace AxarDB
                 try 
                 {
                     var json = System.Text.Json.JsonSerializer.Serialize(options);
-                    var dict = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(json);
+                    var dict = AxarDB.Helpers.ScriptUtils.SafeDeserializeJson(json) as System.Collections.Generic.IDictionary<string, object>;
                     if (dict != null && dict.ContainsKey("priority"))
                     {
                          job["priority"] = Convert.ToInt32(dict["priority"]);
@@ -631,7 +631,7 @@ namespace AxarDB
             return path;
         }
 
-        public object? ExecuteView(string viewName, Dictionary<string, object>? parameters, string clientIp, string user, CancellationToken cancellationToken = default)
+        public object? ExecuteView(string viewName, System.Collections.Generic.IDictionary<string, object>? parameters, string clientIp, string user, CancellationToken cancellationToken = default)
         {
             var context = new ScriptContext 
             { 
@@ -993,7 +993,7 @@ namespace AxarDB
                 if (parameters != null)
                 {
                     var paramJson = System.Text.Json.JsonSerializer.Serialize(parameters);
-                    var paramDict = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(paramJson);
+                    var paramDict = AxarDB.Helpers.ScriptUtils.SafeDeserializeJson(paramJson) as System.Collections.Generic.IDictionary<string, object>;
                     
                     if (paramDict != null)
                     {
@@ -1048,7 +1048,7 @@ namespace AxarDB
                 if (parameters != null)
                 {
                     var paramJson = System.Text.Json.JsonSerializer.Serialize(parameters);
-                    var paramDict = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(paramJson);
+                    var paramDict = AxarDB.Helpers.ScriptUtils.SafeDeserializeJson(paramJson) as System.Collections.Generic.IDictionary<string, object>;
                     
                     if (paramDict != null)
                     {

--- a/DatabaseEngine.cs
+++ b/DatabaseEngine.cs
@@ -337,6 +337,30 @@ namespace AxarDB
             ");
         }
 
+        public void DeleteCollection(string name)
+        {
+            if (_collections.TryRemove(name, out _))
+            {
+                // Already removed from in-memory dictionary
+            }
+
+            // Disk Delete
+            var path = Path.Combine(_basePath, "Data", name);
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, true);
+            }
+
+            // Cache Invalidation for all documents in this collection
+            // Since we use "{Name}:{id}" as key, we can't easily bulk delete from IMemoryCache 
+            // without keeping track of all keys or using a different cache structure.
+            // However, since the collection object is gone and disk is gone, 
+            // the old cache entries will eventually expire. 
+            // For a "clean" delete, we'd need a way to scan keys. 
+            // Given IMemoryCache doesn't support pattern matching, we'll rely on expiration 
+            // OR we accept that orphan cache entries might exist until they expire.
+        }
+
         public DatabaseEngine(string? basePath = null)
         {
             _basePath = basePath ?? AppDomain.CurrentDomain.BaseDirectory;
@@ -453,7 +477,7 @@ namespace AxarDB
 
             // Expose 'UnlockDB' constructor: new UnlockDB("name")
             engine.SetValue("AxarDB", new Func<string, CollectionBridge>(name => {
-                return new CollectionBridge(GetCollection(name), engine, cancellationToken);
+                return new CollectionBridge(this, GetCollection(name), engine, cancellationToken);
             }));
 
             // Expose 'showCollections'
@@ -685,7 +709,7 @@ namespace AxarDB
                 // Bridges
                 var dbBridge = new AxarDBBridge(this, engine, cancellationToken);
                 engine.SetValue("db", dbBridge);
-                engine.SetValue("AxarDB", new Func<string, CollectionBridge>(name => new CollectionBridge(GetCollection(name), engine, cancellationToken)));
+                engine.SetValue("AxarDB", new Func<string, CollectionBridge>(name => new CollectionBridge(this, GetCollection(name), engine, cancellationToken)));
                 engine.SetValue("showCollections", new Func<List<string>>(() => _collections.Keys.ToList())); // Simplified for view
                 RegisterUtils(engine, context);
                 // Ideally ExecuteScript should be refactored. 

--- a/Helpers/LlmClient.cs
+++ b/Helpers/LlmClient.cs
@@ -34,14 +34,12 @@ namespace AxarDB.Helpers
 
             // 2. Prepare Request Body
             var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
-            
-            // Deserialize requestData to a Dictionary to merge fields
             var requestBody = new Dictionary<string, object>();
             
             if (requestData != null)
             {
                 string jsonPart = JsonSerializer.Serialize(requestData);
-                var dict = JsonSerializer.Deserialize<Dictionary<string, object>>(jsonPart);
+                var dict = AxarDB.Helpers.ScriptUtils.SafeDeserializeJson(jsonPart) as System.Collections.Generic.IDictionary<string, object>;
                 if (dict != null)
                 {
                     foreach (var kvp in dict)
@@ -115,7 +113,7 @@ namespace AxarDB.Helpers
                         }
 
                         // Parse to generic object/dictionary
-                        var resultObj = JsonSerializer.Deserialize<object>(cleanContent.Trim());
+                        var resultObj = AxarDB.Helpers.ScriptUtils.SafeDeserializeJson(cleanContent.Trim());
                         return resultObj;
                     }
                     catch (Exception ex)

--- a/Helpers/ScriptUtils.cs
+++ b/Helpers/ScriptUtils.cs
@@ -135,6 +135,26 @@ namespace AxarDB.Helpers
             return 0;
         }
 
+        public static object? SafeDeserializeJson(string json)
+        {
+            if (string.IsNullOrWhiteSpace(json)) return null;
+            try
+            {
+                var settings = new Newtonsoft.Json.JsonSerializerSettings
+                {
+                    Converters = new System.Collections.Generic.List<Newtonsoft.Json.JsonConverter> 
+                    { 
+                        new Newtonsoft.Json.Converters.ExpandoObjectConverter() 
+                    }
+                };
+                return Newtonsoft.Json.JsonConvert.DeserializeObject<object>(json, settings);
+            }
+            catch
+            {
+                return json;
+            }
+        }
+
         public static object? DeepCopy(object? obj)
         {
             if (obj == null) return null;
@@ -213,7 +233,20 @@ namespace AxarDB.Helpers
                 try
                 {
                     var serialized = System.Text.Json.JsonSerializer.Serialize(input);
-                    var deserialized = System.Text.Json.JsonSerializer.Deserialize<List<Dictionary<string, object>>>(serialized);
+                    var deserializedObj = SafeDeserializeJson(serialized);
+                    var deserialized = new List<IDictionary<string, object>>();
+                    
+                    if (deserializedObj is IEnumerable<object> list)
+                    {
+                        foreach (var item in list)
+                        {
+                            if (item is IDictionary<string, object> dict) deserialized.Add(dict);
+                        }
+                    }
+                    else if (deserializedObj is IDictionary<string, object> singleDict)
+                    {
+                        deserialized.Add(singleDict);
+                    }
                     
                     if (deserialized == null || deserialized.Count == 0) return string.Empty;
 

--- a/Program.cs
+++ b/Program.cs
@@ -223,6 +223,12 @@ app.MapGet("/collections", () =>
     return Results.Json(dbEngine.ExecuteScript("showCollections()"));
 });
 
+app.MapDelete("/collections/{name}", (string name) => 
+{
+    dbEngine.DeleteCollection(name);
+    return Results.Ok(new { success = true });
+});
+
 app.MapGet("/docs", () => Results.Redirect("/docs.html"));
 
 app.MapPost("/query", async (HttpContext context) =>
@@ -329,6 +335,18 @@ app.MapGet("/views/{viewName}", async (string viewName, HttpContext context) =>
     {
         return Results.Problem(ex.Message);
     }
+});
+
+app.MapDelete("/views/{viewName}", (string viewName) => 
+{
+    dbEngine.DeleteView(viewName);
+    return Results.Ok(new { success = true });
+});
+
+app.MapDelete("/triggers/{triggerName}", (string triggerName) => 
+{
+    dbEngine.DeleteTrigger(triggerName);
+    return Results.Ok(new { success = true });
 });
 
 app.Run();

--- a/wwwroot/docs.html
+++ b/wwwroot/docs.html
@@ -343,6 +343,11 @@
             color: #3b82f6;
         }
 
+        .method-delete {
+            background: #ef444420;
+            color: #ef4444;
+        }
+
         .info-box {
             background: #3b82f610;
             border: 1px solid #3b82f640;
@@ -572,7 +577,12 @@ db.users.<span class="function">update</span>(u => u.name == <span class="string
 db.users.<span class="function">findall</span>(u => u.inactive).<span class="function">update</span>({ status: <span class="string">"archived"</span> });</code></pre>
 
                 <h3>delete</h3>
-                <pre><code>db.users.<span class="function">findall</span>(u => u.inactive == <span class="keyword">true</span>).<span class="function">delete</span>();</code></pre>
+                <pre><code><span class="comment">// Delete Documents (Filtered)</span>
+db.users.<span class="function">findall</span>(u => u.inactive == <span class="keyword">true</span>).<span class="function">delete</span>();
+
+<span class="comment">// Delete Entire Collection (RAM + Disk)</span>
+db.users.<span class="function">delete</span>();
+db.<span class="function">deleteCollection</span>(<span class="string">"users"</span>);</code></pre>
 
                 <h3>foreach</h3>
                 <pre><code>db.users.<span class="function">findall</span>().<span class="function">foreach</span>(user => {
@@ -798,9 +808,16 @@ event.timestamp   <span class="comment">// Server time (ISO format)</span></code
                             <td>✓</td>
                         </tr>
                         <tr>
+                        <tr>
                             <td><code>/collections</code></td>
                             <td><span class="method method-get">GET</span></td>
                             <td>List collections</td>
+                            <td>✓</td>
+                        </tr>
+                        <tr>
+                            <td><code>/collections/{name}</code></td>
+                            <td><span class="method method-delete">DELETE</span></td>
+                            <td>Delete collection (RAM + Disk)</td>
                             <td>✓</td>
                         </tr>
                         <tr>
@@ -808,6 +825,18 @@ event.timestamp   <span class="comment">// Server time (ISO format)</span></code
                             <td><span class="method method-get">GET</span></td>
                             <td>Run public view</td>
                             <td>@access</td>
+                        </tr>
+                        <tr>
+                            <td><code>/views/{name}</code></td>
+                            <td><span class="method method-delete">DELETE</span></td>
+                            <td>Delete view</td>
+                            <td>✓</td>
+                        </tr>
+                        <tr>
+                            <td><code>/triggers/{name}</code></td>
+                            <td><span class="method method-delete">DELETE</span></td>
+                            <td>Delete trigger</td>
+                            <td>✓</td>
                         </tr>
                     </tbody>
                 </table>
@@ -872,9 +901,33 @@ console.<span class="function">log</span>(<span class="string">"Message"</span>)
 <span class="comment">// Deep copy object</span>
 <span class="keyword">var</span> copy = <span class="function">deepcopy</span>(original);
 
+<span class="comment">// HTTP GET request</span>
+<span class="keyword">var</span> res = <span class="function">httpGet</span>(<span class="string">"https://api.example.com"</span>, { <span class="string">"Auth"</span>: <span class="string">"..."</span> });
+
+<span class="comment">// OpenAI compatible LLM Client</span>
+<span class="keyword">var</span> ai = <span class="function">openai</span>(url, token);
+
+<span class="comment">// AES Encryption / Decryption</span>
+<span class="keyword">var</span> secret = <span class="function">encrypt</span>(<span class="string">"hello"</span>, <span class="string">"salt"</span>);
+<span class="keyword">var</span> plain = <span class="function">decrypt</span>(secret, <span class="string">"salt"</span>);
+
+<span class="comment">// Hash functions (MD5)</span>
+<span class="keyword">var</span> m = <span class="function">md5</span>(<span class="string">"test"</span>);
+
 <span class="comment">// Date manipulation</span>
 <span class="keyword">var</span> nextWeek = <span class="function">addDays</span>(<span class="keyword">new</span> Date(), <span class="number">7</span>);
-<span class="keyword">var</span> later = <span class="function">addMinutes</span>(<span class="keyword">new</span> Date(), <span class="number">15</span>);</code></pre>
+<span class="keyword">var</span> later = <span class="function">addMinutes</span>(<span class="keyword">new</span> Date(), <span class="number">15</span>);
+<span class="keyword">var</span> hourLater = <span class="function">addHours</span>(<span class="keyword">new</span> Date(), <span class="number">1</span>);
+
+<span class="comment">// Converters</span>
+<span class="keyword">var</span> b64 = <span class="function">toBase64</span>(<span class="string">"text"</span>);
+<span class="keyword">var</span> txt = <span class="function">fromBase64</span>(b64);
+<span class="keyword">var</span> num = <span class="function">toDecimal</span>(<span class="string">"10.5"</span>);
+<span class="keyword">var</span> json = <span class="function">toJson</span>({a: <span class="number">1</span>});
+
+<span class="comment">// Randoms</span>
+<span class="keyword">var</span> n = <span class="function">randomNumber</span>(<span class="number">1</span>, <span class="number">100</span>);
+<span class="keyword">var</span> d = <span class="function">randomDecimal</span>(<span class="number">0</span>, <span class="number">1</span>);</code></pre>
             </section>
 
         </div>

--- a/wwwroot/js/app.js
+++ b/wwwroot/js/app.js
@@ -277,7 +277,8 @@ db.${name}
                 e.preventDefault();
                 showContextMenu(e, [
                     { label: `Default Query`, action: () => { setEditorValue(`db.${name}.findall().take(5)`); executeSelectedQuery(); } },
-                    { label: `Clear ${name}`, action: () => { setEditorValue(`db.${name}.findall().delete()`); } }
+                    { label: `Clear ${name}`, action: () => { setEditorValue(`db.${name}.findall().delete()`); } },
+                    { label: `Delete ${name}`, action: () => { if (confirm(`Are you sure you want to delete collection '${name}' and all its data?`)) { deleteCollection(name); } } }
                 ]);
             };
             tree.appendChild(item);
@@ -356,7 +357,16 @@ db.saveView("ActiveUsers", \`
                             }
                         }
                     },
-                    { label: 'Delete View', action: () => { setEditorValue(`db.deleteView("${vName}")`); executeSelectedQuery(); loadCollections(); } }
+                    {
+                        label: 'Delete View',
+                        action: async () => {
+                            if (confirm(`Delete view '${vName}'?`)) {
+                                const res = await fetchWithAuth(`/views/${vName}`, { method: 'DELETE' });
+                                if (res.ok) loadCollections();
+                                else alert('Failed to delete view');
+                            }
+                        }
+                    }
                 ]);
             };
             tree.appendChild(item);
@@ -419,7 +429,16 @@ db.saveTrigger("NotifyAdminOnUserChange", "sysusers", \`
                             if (res.ok) setEditorValue(await res.json());
                         }
                     },
-                    { label: 'Delete Trigger', action: () => { setEditorValue(`db.deleteTrigger("${tName}")`); executeSelectedQuery(); loadCollections(); } }
+                    {
+                        label: 'Delete Trigger',
+                        action: async () => {
+                            if (confirm(`Delete trigger '${tName}'?`)) {
+                                const res = await fetchWithAuth(`/triggers/${tName}`, { method: 'DELETE' });
+                                if (res.ok) loadCollections();
+                                else alert('Failed to delete trigger');
+                            }
+                        }
+                    }
                 ]);
             };
             tree.appendChild(item);
@@ -798,6 +817,20 @@ function exportData(data, format) {
     const blob = new Blob([content], { type: format === 'json' ? 'application/json' : 'text/csv' });
     const url = window.URL.createObjectURL(blob);
     const a = document.createElement('a'); a.href = url; a.download = `export_${new Date().getTime()}.${format} `; a.click();
+}
+
+async function deleteCollection(name) {
+    try {
+        const res = await fetchWithAuth(`/collections/${name}`, { method: 'DELETE' });
+        if (res.ok) {
+            loadCollections();
+        } else {
+            const data = await res.json();
+            alert('Delete failed: ' + (data.error || 'Unknown error'));
+        }
+    } catch (err) {
+        alert('Delete failed: ' + err.message);
+    }
 }
 
 async function fetchWithAuth(url, options = {}) {


### PR DESCRIPTION
## Context
The goal was to fix the execution traces where debug messages arbitrarily cut the scripts generated, omitting core logic with ellipses (`...`), and to correct the behavior of `console.log` within scripts so that output translates practically into the `debug_logs` repository instead of standard console bounds unused by server administrators.

## Actions Taken

### 1. Removing Mutilating Truncations
- Intercepted the execution entry logs in `DatabaseEngine.cs` (Line 407 `ExecuteScript`). Modified the `String` template that previously sliced context and appended `...`, forcing it to fully represent incoming logic traces mapped dynamically via structural replacements.
- Purged identical truncation paradigms injected deeply into `BackgroundServices/QueueProcessor.cs`.

### 2. Output Stream Redirections
- Relinked `engine.SetValue("console")` natively operating under the `DatabaseEngine.cs` builder to stop broadcasting to standard output (C# `Console.WriteLine`) and instead tunnel inputs directly inside formatted arrays to `AxarDB.Logging.Logger.LogDebug`. This guarantees custom Javascript messages output cleanly under the DB trace index.