### PR TITLE
feat: implement core database engine with support for utf8 encoding

### DIFF
--- a/BackgroundServices/QueueProcessor.cs
+++ b/BackgroundServices/QueueProcessor.cs
@@ -8,6 +8,7 @@ using System.IO;
 using AxarDB;
 using AxarDB.Core;
 using AxarDB.Definitions;
+using System.Text;
 
 namespace AxarDB.BackgroundServices
 {
@@ -199,7 +200,7 @@ namespace AxarDB.BackgroundServices
                  string path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "queue_logs");
                  if (!Directory.Exists(path)) Directory.CreateDirectory(path);
                  
-                 File.WriteAllText(Path.Combine(path, $"{jobId}_{DateTime.UtcNow.Ticks}.json"), json);
+                 File.WriteAllText(Path.Combine(path, $"{jobId}_{DateTime.UtcNow.Ticks}.json"), json, Encoding.UTF8);
              }
              catch (Exception ex)
              {

--- a/Bridges/BulkStore.cs
+++ b/Bridges/BulkStore.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Text.Json;
+using System.Text;
 
 namespace AxarDB.Bridges
 {
@@ -113,7 +114,7 @@ namespace AxarDB.Bridges
             }
 
             // Append to file
-            File.AppendAllLines(path, lines);
+            File.AppendAllLines(path, lines, Encoding.UTF8);
 
             // Invalidate cache so it reloads fresh
             InvalidateCache(name);
@@ -139,7 +140,7 @@ namespace AxarDB.Bridges
             var docs = GetDocuments(name).ToList();
             var remaining = docs.Where(d => !predicate(d)).ToList();
             var path = GetFilePath(name);
-            File.WriteAllLines(path, remaining.Select(d => JsonSerializer.Serialize(d)));
+            File.WriteAllLines(path, remaining.Select(d => JsonSerializer.Serialize(d)), Encoding.UTF8);
             InvalidateCache(name);
         }
 
@@ -155,7 +156,7 @@ namespace AxarDB.Bridges
 
             try
             {
-                foreach (var line in File.ReadLines(path))
+                foreach (var line in File.ReadLines(path, Encoding.UTF8))
                 {
                     if (string.IsNullOrWhiteSpace(line)) continue;
                     try

--- a/Bridges/LogCollectionBridge.cs
+++ b/Bridges/LogCollectionBridge.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using AxarDB.Wrappers;
 using AxarDB.Core;
+using System.Text;
 
 namespace AxarDB.Bridges
 {
@@ -47,7 +48,7 @@ namespace AxarDB.Bridges
                 foreach (var file in files)
                 {
                     _cancellationToken.ThrowIfCancellationRequested();
-                    var lines = File.ReadAllLines(file);
+                    var lines = File.ReadAllLines(file, Encoding.UTF8);
                     foreach (var line in lines)
                     {
                         if (string.IsNullOrWhiteSpace(line)) continue;

--- a/Core/DatabaseEngine.cs
+++ b/Core/DatabaseEngine.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using MySqlConnector;
 using Npgsql;
+using System.Text;
 
 namespace AxarDB.Core
 {
@@ -720,7 +721,7 @@ namespace AxarDB.Core
                 var viewPath = Path.Combine(GetViewsPath(), viewName + ".js");
                 if (!File.Exists(viewPath)) throw new FileNotFoundException($"View '{viewName}' not found.");
 
-                var script = File.ReadAllText(viewPath);
+                var script = File.ReadAllText(viewPath, Encoding.UTF8);
                 
                 //FOR AI TESTING PURPOSES
                 // Access Control Check (for HTTP calls mostly, but good to enforce)
@@ -825,7 +826,7 @@ namespace AxarDB.Core
                 };
                 
                 var logJson = System.Text.Json.JsonSerializer.Serialize(logEntry, new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
-                File.WriteAllText(Path.Combine(GetLogsPath(), $"{viewName}_{DateTime.UtcNow.Ticks}.json"), logJson);
+                File.WriteAllText(Path.Combine(GetLogsPath(), $"{viewName}_{DateTime.UtcNow.Ticks}.json"), logJson, Encoding.UTF8);
             }
             
             return result;
@@ -837,7 +838,7 @@ namespace AxarDB.Core
             if (!File.Exists(viewPath)) return "private"; 
             
             // Read first few lines
-            foreach(var line in File.ReadLines(viewPath).Take(5))
+            foreach(var line in File.ReadLines(viewPath, Encoding.UTF8).Take(5))
             {
                 if (line.Contains("@access public")) return "public";
             }
@@ -846,7 +847,7 @@ namespace AxarDB.Core
 
         public void SaveView(string name, string content)
         {
-            File.WriteAllText(Path.Combine(GetViewsPath(), name + ".js"), content);
+            File.WriteAllText(Path.Combine(GetViewsPath(), name + ".js"), content, Encoding.UTF8);
         }
 
         public void DeleteView(string name)
@@ -865,7 +866,7 @@ namespace AxarDB.Core
         public string? GetViewContent(string name)
         {
             var path = Path.Combine(GetViewsPath(), name + ".js");
-            return File.Exists(path) ? File.ReadAllText(path) : null;
+            return File.Exists(path) ? File.ReadAllText(path, Encoding.UTF8) : null;
         }
 
         // ---------------------------------------------------------
@@ -943,7 +944,7 @@ namespace AxarDB.Core
                     
                     foreach(var triggerPath in triggers)
                     {
-                        var content = File.ReadAllText(triggerPath);
+                        var content = File.ReadAllText(triggerPath, Encoding.UTF8);
                         // Parse header: // @target collectionName
                         if (content.Contains($"@target {collectionName}") || content.Contains("@target *"))
                         {
@@ -1019,7 +1020,7 @@ namespace AxarDB.Core
                 // Simple file append with lock to ensure thread safety
                 lock(_logLock) 
                 {
-                    File.AppendAllText(path, line + Environment.NewLine);
+                    File.AppendAllText(path, line + Environment.NewLine, Encoding.UTF8);
                 }
             } 
             catch {}
@@ -1037,7 +1038,7 @@ namespace AxarDB.Core
         public string? GetTriggerContent(string name)
         {
             var path = Path.Combine(GetTriggersPath(), name + ".js");
-            return File.Exists(path) ? File.ReadAllText(path) : null;
+            return File.Exists(path) ? File.ReadAllText(path, Encoding.UTF8) : null;
         }
 
         public void SaveTrigger(string name, string targetCollection, string content)
@@ -1046,7 +1047,7 @@ namespace AxarDB.Core
             {
                 content = $"// @target {targetCollection}\n" + content;
             }
-            File.WriteAllText(Path.Combine(GetTriggersPath(), name + ".js"), content);
+            File.WriteAllText(Path.Combine(GetTriggersPath(), name + ".js"), content, Encoding.UTF8);
         }
         
         public void SaveTrigger(string name, string content) => SaveTrigger(name, "*", content);

--- a/Definitions/Collection.cs
+++ b/Definitions/Collection.cs
@@ -161,8 +161,9 @@ namespace AxarDB.Definitions
                                .Select(id => GetDocument(id))
                                .Where(doc => doc != null)
                                .Select(doc => doc!)
+                               .Where(predicate)
                                .ToList();
-                     return docs.Where(predicate);
+                     return docs;
                  }
              }
 
@@ -174,8 +175,9 @@ namespace AxarDB.Definitions
                           .Select(id => GetDocument(id))
                           .Where(doc => doc != null)
                           .Select(doc => doc!)
+                          .Where(predicate)
                           .ToList();
-             return allDocs.Where(predicate);
+             return allDocs;
         }
 
         public void CreateIndex(string propertyName, string type)

--- a/Definitions/IndexDefinition.cs
+++ b/Definitions/IndexDefinition.cs
@@ -102,7 +102,7 @@ namespace AxarDB.Definitions
              // Serialize: Num index keys must be strings for JSON
              var numDict = NumericIndex.ToDictionary(k => k.Key.ToString(System.Globalization.CultureInfo.InvariantCulture), v => v.Value);
              var data = new { Prop = PropertyName, Type = Type, Txt = TextIndex, Num = numDict };
-             File.WriteAllText(path, JsonSerializer.Serialize(data));
+             File.WriteAllText(path, JsonSerializer.Serialize(data), System.Text.Encoding.UTF8);
         }
 
         public static IndexDefinition? Load(string path)
@@ -110,7 +110,7 @@ namespace AxarDB.Definitions
              if(!File.Exists(path)) return null;
              try 
              {
-                 var json = File.ReadAllText(path);
+                 var json = File.ReadAllText(path, System.Text.Encoding.UTF8);
                  // Deserialize to dynamic or element to handle manual parsing
                  using var doc = JsonDocument.Parse(json);
                  var root = doc.RootElement;

--- a/Helpers/ScriptUtils.cs
+++ b/Helpers/ScriptUtils.cs
@@ -91,7 +91,7 @@ namespace AxarDB.Helpers
                 var encryptor = aes.CreateEncryptor(aes.Key, aes.IV);
                 using var ms = new MemoryStream();
                 using (var cs = new CryptoStream(ms, encryptor, CryptoStreamMode.Write))
-                using (var sw = new StreamWriter(cs))
+                using (var sw = new StreamWriter(cs, Encoding.UTF8))
                 {
                     sw.Write(text);
                 }
@@ -117,7 +117,7 @@ namespace AxarDB.Helpers
                 var decryptor = aes.CreateDecryptor(aes.Key, aes.IV);
                 using var ms = new MemoryStream(Convert.FromBase64String(encryptedBase64));
                 using var cs = new CryptoStream(ms, decryptor, CryptoStreamMode.Read);
-                using var sr = new StreamReader(cs);
+                using var sr = new StreamReader(cs, Encoding.UTF8);
                 return sr.ReadToEnd();
             } 
             catch { return ""; }

--- a/Logging/Logger.cs
+++ b/Logging/Logger.cs
@@ -32,7 +32,7 @@ namespace AxarDB.Logging
                 
                 lock (_lock)
                 {
-                    File.AppendAllLines(filePath, new[] { logLine });
+                    File.AppendAllLines(filePath, new[] { logLine }, System.Text.Encoding.UTF8);
                 }
             }
             catch
@@ -54,7 +54,7 @@ namespace AxarDB.Logging
                 
                 lock (_lock)
                 {
-                    File.AppendAllLines(filePath, new[] { logLine });
+                    File.AppendAllLines(filePath, new[] { logLine }, System.Text.Encoding.UTF8);
                 }
             }
             catch
@@ -76,7 +76,7 @@ namespace AxarDB.Logging
                 
                 lock (_lock)
                 {
-                    File.AppendAllLines(filePath, new[] { logLine });
+                    File.AppendAllLines(filePath, new[] { logLine }, System.Text.Encoding.UTF8);
                 }
 
                 // Still write to console if in Debug build or environment, 

--- a/Program.cs
+++ b/Program.cs
@@ -2,12 +2,15 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using System.Text;
 using System.Diagnostics;
+using System.Globalization;
 using AxarDB;
 using AxarDB.Core;
 using AxarDB.Diagnostics;
 using AxarDB.Logging;
 
-// Ensure Console Output is UTF8
+// Set global culture and encoding
+CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("tr-TR");
+CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("tr-TR");
 Console.OutputEncoding = Encoding.UTF8;
 
 
@@ -27,7 +30,7 @@ if (args.Length > 0 && args[0] == "script")
         var db = new DatabaseEngine(tPath);
         try 
         {
-            var content = File.ReadAllText(scriptPath);
+            var content = File.ReadAllText(scriptPath, Encoding.UTF8);
             var result = db.ExecuteScript(content);
             Console.WriteLine("Result: " + (result?.ToString() ?? "null"));
         }

--- a/SDKs/cli/AxarDB.Cli/Program.cs
+++ b/SDKs/cli/AxarDB.Cli/Program.cs
@@ -1,7 +1,9 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
+using System.Globalization;
+using System.Text;
 using AxarDB.Sdk;
 
 namespace AxarDB.Cli
@@ -10,6 +12,11 @@ namespace AxarDB.Cli
     {
         static async Task Main(string[] args)
         {
+            // Set global culture and encoding
+            CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("tr-TR");
+            CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("tr-TR");
+            Console.OutputEncoding = Encoding.UTF8;
+
             try
             {
                 var options = ParseArguments(args);
@@ -68,7 +75,7 @@ namespace AxarDB.Cli
                         Console.WriteLine($"Error: Script file not found: {options.ScriptFile}");
                         return;
                     }
-                    script = File.ReadAllText(options.ScriptFile);
+                    script = File.ReadAllText(options.ScriptFile, Encoding.UTF8);
                 }
                 else if (!string.IsNullOrEmpty(options.InlineScript))
                 {
@@ -92,7 +99,7 @@ namespace AxarDB.Cli
 
                 if (!string.IsNullOrEmpty(options.OutputFile))
                 {
-                    File.WriteAllText(options.OutputFile, jsonOutput);
+                    File.WriteAllText(options.OutputFile, jsonOutput, Encoding.UTF8);
                     Console.WriteLine($"Result written to {options.OutputFile}");
                 }
                 else


### PR DESCRIPTION
## 🌟 New Features & Improvements

### 1. Global Culture & Console Encoding Lock
- Locked the application culture to `tr-TR` globally on all threads via `CultureInfo.DefaultThreadCurrentCulture` and `CultureInfo.DefaultThreadCurrentUICulture`.
- Fixed the console output encoding to `Encoding.UTF8` at startup.
- Applied these configuration settings to both the core AxarDB server engine and the AxarDB CLI client.

### 2. Parallelized Search Predicates
- Re-parallelized query predicate evaluation in `Collection.FindAll`. Moved the `.Where(predicate)` filter back inside the PLINQ (`AsParallel()`) expression prior to materialization. This resolves search slowdowns and significantly speeds up parallel data queries.

### 3. Explicit UTF-8 Filesystem Operations
- Enforced explicit `Encoding.UTF8` usage across all file reading, writing, appending, and stream processing operations. This ensures that data is stored and retrieved consistently regardless of the host OS default encoding.
- Updated file operations in:
  - `Program.cs` and `AxarDB.Cli/Program.cs`
  - `Core/DatabaseEngine.cs`
  - `Definitions/IndexDefinition.cs`
  - `Bridges/BulkStore.cs` & `Bridges/LogCollectionBridge.cs`
  - `BackgroundServices/QueueProcessor.cs`
  - `Logging/Logger.cs`
  - `Helpers/ScriptUtils.cs` (Crypto streams)