### PR TITLE
BulkStore for JSONL collection search make faster

### DIFF
--- a/AxarDB.csproj
+++ b/AxarDB.csproj
@@ -27,12 +27,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="wwwroot\unlockerdbLogo.png">
+    <Content Update="wwwroot\unlockerdbLogo.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="appsettings.json">
+    </Content>
+    <Content Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/Bootstrap/AppBootstrap.cs
+++ b/Bootstrap/AppBootstrap.cs
@@ -26,7 +26,7 @@ namespace AxarDB.Bootstrap
             Console.OutputEncoding = Encoding.UTF8;
 
             var startupOptions = StartupOptions.Parse(args);
-            var settings = ConfigHelper.LoadSettings(args);
+            var settings = ConfigHelper.LoadSettings(startupOptions.TargetPath);
 
             if (startupOptions.IsScript)
             {

--- a/Bridges/AxarDBBridge.cs
+++ b/Bridges/AxarDBBridge.cs
@@ -19,6 +19,16 @@ namespace AxarDB.Bridges
 
         public override bool TryGetMember(GetMemberBinder binder, out object? result)
         {
+            // Block access to custom sys-prefixed collections
+            if (binder.Name.StartsWith("sys", StringComparison.OrdinalIgnoreCase) &&
+                !binder.Name.Equals("sysusers", StringComparison.OrdinalIgnoreCase) &&
+                !binder.Name.Equals("sysqueue", StringComparison.OrdinalIgnoreCase) &&
+                !binder.Name.Equals("sysvaults", StringComparison.OrdinalIgnoreCase) &&
+                !binder.Name.Equals("sysconfig", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException($"System collection name '{binder.Name}' is reserved.");
+            }
+
             // db.users -> returns CollectionBridge for "users"
             var collection = _dbEngine.GetCollection(binder.Name);
             result = new CollectionBridge(_dbEngine, collection, _jintEngine, _cancellationToken);

--- a/Bridges/BulkCollectionBridge.cs
+++ b/Bridges/BulkCollectionBridge.cs
@@ -36,10 +36,11 @@ namespace AxarDB.Bridges
         /// <summary>Returns a BulkResultSet of all documents, optionally filtered.</summary>
         public BulkResultSet findall(JsValue? predicate = null)
         {
-            var all = _store.GetDocuments(_collectionName);
-
             if (predicate == null || predicate.IsNull() || predicate.IsUndefined())
+            {
+                var all = _store.GetDocuments(_collectionName);
                 return new BulkResultSet(all, _store, _collectionName);
+            }
 
             Func<Dictionary<string, object>, bool> csPredicate = (d) =>
             {
@@ -55,47 +56,73 @@ namespace AxarDB.Bridges
                 }
             };
 
-            return new BulkResultSet(all.Where(csPredicate), _store, _collectionName);
+            var filterFields = AxarDB.Query.QueryOptimizer.ExtractAccessedProperties(predicate);
+            var results = _store.QueryChunks(_collectionName, filterFields, csPredicate);
+            return new BulkResultSet(results, _store, _collectionName);
         }
 
         /// <summary>Returns the first document matching the predicate, or null.</summary>
-        public DocumentWrapper? find(Func<object, bool> predicate)
+        public DocumentWrapper? find(JsValue predicate)
         {
-            var doc = _store.GetDocuments(_collectionName)
-                .FirstOrDefault(d =>
+            Func<Dictionary<string, object>, bool> csPredicate = (d) =>
+            {
+                if (_engine == null) return true;
+                lock (_engine)
                 {
-                    if (_engine != null) lock (_engine) { try { return predicate(new DocumentWrapper(d)); } catch { return false; } }
-                    return predicate(new DocumentWrapper(d));
-                });
+                    try
+                    {
+                        var result = _engine.Invoke(predicate, new object[] { new DocumentWrapper(d) });
+                        return result.AsBoolean();
+                    }
+                    catch { return false; }
+                }
+            };
+
+            var filterFields = AxarDB.Query.QueryOptimizer.ExtractAccessedProperties(predicate);
+            var doc = _store.QueryChunks(_collectionName, filterFields, csPredicate).FirstOrDefault();
             return doc != null ? new DocumentWrapper(doc) : null;
         }
 
-        public BulkResultSet contains(Func<object, bool> predicate)
+        public BulkResultSet contains(JsValue predicate)
         {
             Func<Dictionary<string, object>, bool> safePredicate = (d) =>
             {
-                if (_engine == null) return predicate(new CaseInsensitiveDocumentWrapper(d));
+                if (_engine == null) return true;
                 lock (_engine)
                 {
-                    try { return predicate(new CaseInsensitiveDocumentWrapper(d)); } catch { return false; }
+                    try
+                    {
+                        var result = _engine.Invoke(predicate, new object[] { new CaseInsensitiveDocumentWrapper(d) });
+                        return result.AsBoolean();
+                    }
+                    catch { return false; }
                 }
             };
-            var all = _store.GetDocuments(_collectionName);
-            return new BulkResultSet(all.Where(safePredicate), _store, _collectionName);
+
+            var filterFields = AxarDB.Query.QueryOptimizer.ExtractAccessedProperties(predicate);
+            var results = _store.QueryChunks(_collectionName, filterFields, safePredicate);
+            return new BulkResultSet(results, _store, _collectionName);
         }
 
-        public BulkResultSet startsWith(Func<object, bool> predicate)
+        public BulkResultSet startsWith(JsValue predicate)
         {
             Func<Dictionary<string, object>, bool> safePredicate = (d) =>
             {
-                if (_engine == null) return predicate(new CaseInsensitiveDocumentWrapper(d));
+                if (_engine == null) return true;
                 lock (_engine)
                 {
-                    try { return predicate(new CaseInsensitiveDocumentWrapper(d)); } catch { return false; }
+                    try
+                    {
+                        var result = _engine.Invoke(predicate, new object[] { new CaseInsensitiveDocumentWrapper(d) });
+                        return result.AsBoolean();
+                    }
+                    catch { return false; }
                 }
             };
-            var all = _store.GetDocuments(_collectionName);
-            return new BulkResultSet(all.Where(safePredicate), _store, _collectionName);
+
+            var filterFields = AxarDB.Query.QueryOptimizer.ExtractAccessedProperties(predicate);
+            var results = _store.QueryChunks(_collectionName, filterFields, safePredicate);
+            return new BulkResultSet(results, _store, _collectionName);
         }
 
         /// <summary>Manually reload this collection from disk.</summary>

--- a/Bridges/BulkStore.cs
+++ b/Bridges/BulkStore.cs
@@ -204,6 +204,119 @@ namespace AxarDB.Bridges
             }
         }
 
+        public IEnumerable<Dictionary<string, object>> QueryChunks(string name, HashSet<string> filterFields, Func<Dictionary<string, object>, bool> predicate)
+        {
+            var path = GetFilePath(name);
+            if (!File.Exists(path)) yield break;
+
+            var chunkLines = new List<string>();
+            long currentChunkBytes = 0;
+
+            // Read the file line-by-line
+            foreach (var line in File.ReadLines(path, Encoding.UTF8))
+            {
+                if (string.IsNullOrWhiteSpace(line)) continue;
+                chunkLines.Add(line);
+                currentChunkBytes += line.Length * 2;
+
+                // When chunk reaches the cache limit, we process it
+                if (currentChunkBytes >= _maxCacheBytes)
+                {
+                    foreach (var doc in ProcessChunk(chunkLines, filterFields, predicate))
+                    {
+                        yield return doc;
+                    }
+                    chunkLines.Clear();
+                    currentChunkBytes = 0;
+                    
+                    // Force garbage collection of the chunk
+                    GC.Collect(0, GCCollectionMode.Optimized);
+                }
+            }
+
+            // Process the remaining lines in the last chunk
+            if (chunkLines.Count > 0)
+            {
+                foreach (var doc in ProcessChunk(chunkLines, filterFields, predicate))
+                {
+                    yield return doc;
+                }
+                chunkLines.Clear();
+            }
+        }
+
+        private IEnumerable<Dictionary<string, object>> ProcessChunk(List<string> lines, HashSet<string> filterFields, Func<Dictionary<string, object>, bool> predicate)
+        {
+            var matchedDocs = new List<Dictionary<string, object>>();
+
+            // 1. Build temporary lightweight index in memory
+            var tempIndex = new List<(int index, Dictionary<string, object> fields)>();
+            for (int i = 0; i < lines.Count; i++)
+            {
+                var lightDoc = ParseSelectedProperties(lines[i], filterFields);
+                tempIndex.Add((i, lightDoc));
+            }
+
+            // 2. Perform prediction (filtering) on the temporary index
+            foreach (var entry in tempIndex)
+            {
+                if (predicate(entry.fields))
+                {
+                    // 3. Match found: parse full document
+                    try
+                    {
+                        var fullDoc = JsonSerializer.Deserialize<Dictionary<string, object>>(lines[entry.index], _jsonOptions);
+                        if (fullDoc != null)
+                        {
+                            matchedDocs.Add(fullDoc);
+                        }
+                    }
+                    catch {}
+                }
+            }
+
+            return matchedDocs;
+        }
+
+        private static Dictionary<string, object> ParseSelectedProperties(string json, IEnumerable<string> properties)
+        {
+            var dict = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+            try
+            {
+                using var doc = JsonDocument.Parse(json);
+                var root = doc.RootElement;
+                foreach (var prop in properties)
+                {
+                    if (root.TryGetProperty(prop, out var val))
+                    {
+                        dict[prop] = GetJsonValue(val);
+                    }
+                }
+            }
+            catch {}
+            return dict;
+        }
+
+        private static object GetJsonValue(JsonElement element)
+        {
+            switch (element.ValueKind)
+            {
+                case JsonValueKind.String:
+                    return element.GetString() ?? "";
+                case JsonValueKind.Number:
+                    if (element.TryGetInt64(out long l)) return l;
+                    return element.GetDouble();
+                case JsonValueKind.True:
+                    return true;
+                case JsonValueKind.False:
+                    return false;
+                case JsonValueKind.Null:
+                    return null!;
+                default:
+                    return element.GetRawText(); // fallback for objects/arrays
+            }
+        }
+
         private string GetFilePath(string name)
             => Path.Combine(_bulkPath, $"{name}.jsonl");
 

--- a/Bridges/BulkStore.cs
+++ b/Bridges/BulkStore.cs
@@ -27,6 +27,7 @@ namespace AxarDB.Bridges
                 Directory.CreateDirectory(_bulkPath);
 
             _jsonOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            _jsonOptions.Converters.Add(new AxarDB.Storage.CustomObjectConverter());
             _maxCacheBytes = maxCacheBytes;
 
             // FileSystemWatcher for auto-reload

--- a/Bridges/CollectionBridge.cs
+++ b/Bridges/CollectionBridge.cs
@@ -113,10 +113,12 @@ namespace AxarDB.Bridges
 
         public object? insert(object docObj)
         {
-            if (string.Equals(_collection.Name, "sysqueue", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(_collection.Name, "sysvaults", StringComparison.OrdinalIgnoreCase))
+            if (_collection.Name.StartsWith("sys", StringComparison.OrdinalIgnoreCase))
             {
-                throw new System.InvalidOperationException($"Direct insertion into system collection '{_collection.Name}' is not allowed. Use the appropriate system function instead.");
+                if (!string.Equals(_collection.Name, "sysusers", StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new System.InvalidOperationException($"Direct insertion into system collection '{_collection.Name}' is not allowed.");
+                }
             }
 
             var dict = ConvertToDictionary(docObj);

--- a/Core/DatabaseEngine.cs
+++ b/Core/DatabaseEngine.cs
@@ -443,6 +443,7 @@ namespace AxarDB.Core
             // Create default system collection
             GetCollection("sysusers");
             GetCollection("sysqueue"); // Initialize queue collection
+            GetCollection("sysconfig"); // Initialize config collection
             // Add default user
             var sysusers = GetCollection("sysusers");
             // Check via storage if empty
@@ -453,6 +454,20 @@ namespace AxarDB.Core
                     { "username", "unlocker" },
                     { "password", "unlocker" }
                 });
+            }
+
+            // Seed default configuration settings if empty
+            var sysconfig = GetCollection("sysconfig");
+            if (!sysconfig.FindAll().Any())
+            {
+                sysconfig.Insert(new Dictionary<string, object>
+                {
+                    { "memoryLimitPercentage", Settings.MemoryLimitPercentage },
+                    { "bulkStoreMaxCacheBytes", Settings.BulkStoreMaxCacheBytes },
+                    { "maxRecursionDepth", Settings.MaxRecursionDepth },
+                    { "queryTimeoutMinutes", Settings.QueryTimeoutMinutes },
+                    { "queuePollIntervalSeconds", Settings.QueuePollIntervalSeconds }
+                }, bypassSystemRules: true);
             }
         }
 
@@ -571,6 +586,14 @@ namespace AxarDB.Core
 
             // Expose 'UnlockDB' constructor: new UnlockDB("name")
             engine.SetValue("AxarDB", new Func<string, CollectionBridge>(name => {
+                if (name.StartsWith("sys", StringComparison.OrdinalIgnoreCase) &&
+                    !name.Equals("sysusers", StringComparison.OrdinalIgnoreCase) &&
+                    !name.Equals("sysqueue", StringComparison.OrdinalIgnoreCase) &&
+                    !name.Equals("sysvaults", StringComparison.OrdinalIgnoreCase) &&
+                    !name.Equals("sysconfig", StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException($"System collection name '{name}' is reserved.");
+                }
                 return new CollectionBridge(this, GetCollection(name), engine, cancellationToken);
             }));
 

--- a/Definitions/Collection.cs
+++ b/Definitions/Collection.cs
@@ -96,8 +96,24 @@ namespace AxarDB.Definitions
             return null;
         }
 
-        public void Insert(Dictionary<string, object> document, CancellationToken cancellationToken = default)
+        public void Insert(Dictionary<string, object> document, CancellationToken cancellationToken = default, bool bypassSystemRules = false)
         {
+            if (Name.StartsWith("sys", StringComparison.OrdinalIgnoreCase))
+            {
+                if (!Name.Equals("sysusers", StringComparison.OrdinalIgnoreCase) &&
+                    !Name.Equals("sysqueue", StringComparison.OrdinalIgnoreCase) &&
+                    !Name.Equals("sysvaults", StringComparison.OrdinalIgnoreCase) &&
+                    !Name.Equals("sysconfig", StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException("Users cannot create custom system collections starting with 'sys'.");
+                }
+
+                if (Name.Equals("sysconfig", StringComparison.OrdinalIgnoreCase) && !bypassSystemRules)
+                {
+                    throw new InvalidOperationException("Insert operation is not allowed on sysconfig collection.");
+                }
+            }
+
             if (!document.ContainsKey("_id"))
             {
                 document["_id"] = Guid.NewGuid().ToString();
@@ -208,7 +224,7 @@ namespace AxarDB.Definitions
                      doc[kvp.Key] = kvp.Value;
                  }
                  // Save
-                 Insert(doc, cancellationToken); // Re-inserts/Updates cache & disk
+                 Insert(doc, cancellationToken, bypassSystemRules: true); // Re-inserts/Updates cache & disk
             }
         }
 
@@ -272,6 +288,7 @@ namespace AxarDB.Definitions
         {
             { "sysusers", new HashSet<string> { "_id", "username", "password" } },
             { "sysvaults", new HashSet<string> { "_id", "key", "value", "created" } },
+            { "sysconfig", new HashSet<string> { "_id", "memoryLimitPercentage", "bulkStoreMaxCacheBytes", "maxRecursionDepth", "queryTimeoutMinutes", "queuePollIntervalSeconds" } },
             { "sysqueue", new HashSet<string> { "_id", "queryTemplate", "parameters", "options", "createdAt", "executionTime", "priority", "duration", "successResult", "errorMessage", "completedAt" } }
         };
 
@@ -291,6 +308,17 @@ namespace AxarDB.Definitions
                     { "_id", typeof(string) },
                     { "key", typeof(string) },
                     { "created", typeof(DateTime) }
+                }
+            },
+            {
+                "sysconfig", new Dictionary<string, Type>
+                {
+                    { "_id", typeof(string) },
+                    { "memoryLimitPercentage", typeof(double) },
+                    { "bulkStoreMaxCacheBytes", typeof(long) },
+                    { "maxRecursionDepth", typeof(int) },
+                    { "queryTimeoutMinutes", typeof(int) },
+                    { "queuePollIntervalSeconds", typeof(double) }
                 }
             },
             {

--- a/Definitions/ConfigHelper.cs
+++ b/Definitions/ConfigHelper.cs
@@ -1,50 +1,51 @@
-using Microsoft.Extensions.Configuration;
 using System;
+using System.IO;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace AxarDB.Definitions
 {
     public static class ConfigHelper
     {
-        public static DatabaseSettings LoadSettings(string[] args)
+        public static DatabaseSettings LoadSettings(string? targetPath)
         {
-            var switchMappings = new Dictionary<string, string>
-            {
-                { "--memory-limit", "DatabaseSettings:MemoryLimitPercentage" },
-                { "--bulk-cache-limit", "DatabaseSettings:BulkStoreMaxCacheBytes" },
-                { "--max-recursion", "DatabaseSettings:MaxRecursionDepth" },
-                { "--query-timeout", "DatabaseSettings:QueryTimeoutMinutes" },
-                { "--queue-poll-seconds", "DatabaseSettings:QueuePollIntervalSeconds" }
-            };
+            var basePath = targetPath ?? AppDomain.CurrentDomain.BaseDirectory;
+            var sysconfigDir = Path.Combine(basePath, "Data", "sysconfig");
+            var settings = new DatabaseSettings();
 
-            // Filter args to only pass the configured switches and their values
-            var filteredArgs = new List<string>();
-            for (int i = 0; i < args.Length; i++)
+            if (Directory.Exists(sysconfigDir))
             {
-                if (switchMappings.ContainsKey(args[i]))
+                try
                 {
-                    filteredArgs.Add(args[i]);
-                    if (i + 1 < args.Length)
+                    var files = Directory.GetFiles(sysconfigDir, "*.json");
+                    if (files.Length > 0)
                     {
-                        filteredArgs.Add(args[i + 1]);
-                        i++; // skip value
+                        var content = File.ReadAllText(files[0]);
+                        var dict = JsonConvert.DeserializeObject<Dictionary<string, object>>(content);
+                        if (dict != null)
+                        {
+                            if (dict.TryGetValue("memoryLimitPercentage", out var memVal) && memVal != null)
+                                settings.MemoryLimitPercentage = Convert.ToDouble(memVal, System.Globalization.CultureInfo.InvariantCulture);
+                            
+                            if (dict.TryGetValue("bulkStoreMaxCacheBytes", out var bulkVal) && bulkVal != null)
+                                settings.BulkStoreMaxCacheBytes = Convert.ToInt64(bulkVal);
+
+                            if (dict.TryGetValue("maxRecursionDepth", out var recVal) && recVal != null)
+                                settings.MaxRecursionDepth = Convert.ToInt32(recVal);
+
+                            if (dict.TryGetValue("queryTimeoutMinutes", out var timeoutVal) && timeoutVal != null)
+                                settings.QueryTimeoutMinutes = Convert.ToInt32(timeoutVal);
+
+                            if (dict.TryGetValue("queuePollIntervalSeconds", out var pollVal) && pollVal != null)
+                                settings.QueuePollIntervalSeconds = Convert.ToDouble(pollVal, System.Globalization.CultureInfo.InvariantCulture);
+                        }
                     }
                 }
-                else if (args[i].StartsWith("--DatabaseSettings:", StringComparison.OrdinalIgnoreCase))
+                catch (Exception ex)
                 {
-                    filteredArgs.Add(args[i]);
+                    Console.WriteLine($"[AxarDB Warning] Failed to load settings from sysconfig, using defaults: {ex.Message}");
                 }
             }
-
-            var builder = new ConfigurationBuilder()
-                .SetBasePath(AppDomain.CurrentDomain.BaseDirectory)
-                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                .AddEnvironmentVariables()
-                .AddCommandLine(filteredArgs.ToArray(), switchMappings);
-
-            var config = builder.Build();
-            var settings = new DatabaseSettings();
-            config.GetSection("DatabaseSettings").Bind(settings);
             return settings;
         }
     }

--- a/Docs/README.tr.md
+++ b/Docs/README.tr.md
@@ -70,22 +70,24 @@ dotnet run -- -p 5001 --cors "http://localhost:3000"
 
 ## ⚙️ Yapılandırma (Configuration)
 
-AxarDB, `appsettings.json` dosyası üzerinden özelleştirilebilen veya doğrudan başlatma sırasında komut satırı argümanları ile ezilebilen esnek veritabanı ayarlarına sahiptir.
+AxarDB yapılandırma ayarları, veritabanı içindeki `sysconfig` isimli özel bir sistem koleksiyonunda saklanır. İlk kurulum esnasında bu koleksiyon otomatik olarak varsayılan ayarlar ile doldurulur.
+
+Ayarları değiştirmek için yetkili bir kullanıcı `sysconfig` koleksiyonundaki belgeyi güncelleyebilir. Yeni ayarlar veritabanı sunucusu yeniden başlatıldığında aktif olacaktır. `sysconfig` koleksiyonuna doğrudan ekleme (insert) işlemi yapılmasına izin verilmez.
 
 ### Kullanılabilir Parametreler
 
-| Parametre | Konfigürasyon Anahtarı | Varsayılan Değer | Açıklama |
+| Özellik | Tip | Varsayılan Değer | Açıklama |
 | :--- | :--- | :--- | :--- |
-| `--memory-limit` | `DatabaseSettings:MemoryLimitPercentage` | `0.4` | Veritabanının maksimum bellek kullanım oranını belirler (örn: %30 için `0.3`). |
-| `--bulk-cache-limit` | `DatabaseSettings:BulkStoreMaxCacheBytes` | `52428800` (50MB) | Toplu önbellek boyutu limitidir (byte). |
-| `--max-recursion` | `DatabaseSettings:MaxRecursionDepth` | `100` | Çalıştırılan script'lerin maksimum yineleme (recursion) derinliğini sınırlar. |
-| `--query-timeout` | `DatabaseSettings:QueryTimeoutMinutes` | `10` | Sorgu çalışma süresi sınırıdır (dakika). |
-| `--queue-poll-seconds` | `DatabaseSettings:QueuePollIntervalSeconds` | `1.0` | Arka plan kuyruğunun kontrol edilme sıklığıdır (saniye). |
+| `memoryLimitPercentage` | `double` | `0.4` | Veritabanının maksimum bellek kullanım oranını belirler (örn: %30 için `0.3`). |
+| `bulkStoreMaxCacheBytes` | `long` | `52428800` (50MB) | Toplu önbellek boyutu limitidir (byte). |
+| `maxRecursionDepth` | `int` | `100` | Çalıştırılan script'lerin maksimum yineleme (recursion) derinliğini sınırlar. |
+| `queryTimeoutMinutes` | `int` | `10` | Sorgu çalışma süresi sınırıdır (dakika). |
+| `queuePollIntervalSeconds` | `double` | `1.0` | Arka plan kuyruğunun kontrol edilme sıklığıdır (saniye). |
 
 ### Yapılandırma Örneği
-Veritabanı sunucusunu %30 bellek limiti ve 5 dakikalık sorgu zaman aşımı ile başlatmak için:
-```bash
-dotnet run -- --memory-limit 0.3 --query-timeout 5
+Sorgu konsolu üzerinden ayarları değiştirmek için (etkin olması için sunucu yeniden başlatılmalıdır):
+```javascript
+db.sysconfig.update(x => true, { queryTimeoutMinutes: 15 });
 ```
 
 ---

--- a/Docs/llm_ragfile_en.md
+++ b/Docs/llm_ragfile_en.md
@@ -32,8 +32,8 @@ db.products.insert({ name: "Laptop", price: 999.99, inStock: true });
 
 ### B. Find Data (Reading)
 
-#### `findall()` — Returns a ResultSet (NOT an array)
-> **CRITICAL RULE**: `findall()` returns a `ResultSet`, **NOT** an array. You **MUST** call `.toList()` or `.ToList()` to convert it to an array. Both casing variants work.
+#### `findall()` — Returns a ResultSet (fully chainable and iterable)
+> **NOTE**: `findall()` returns a `ResultSet`, which represents the query result. While it is fully chainable and can be iterated directly in JS loops, you can call `.toList()` or `.ToList()` to convert it to a standard JavaScript array. Both casing variants work.
 
 ```javascript
 // ✅ CORRECT — Get all users as array
@@ -45,9 +45,10 @@ var adults = db.users.findall(u => u.age > 18).toList();
 // ✅ CORRECT — Case variants both work
 var items = db.orders.findall().ToList();
 
-// ❌ WRONG — Returns ResultSet, not array!
-var broken = db.users.findall();
-// broken is NOT iterable as an array
+// ✅ VALID — Returns ResultSet
+var resultSet = db.users.findall();
+// resultSet supports chaining (.take(5), .skip(5), .select(x => x.name), .delete(), .update())
+// and is fully iterable in JS (e.g. for (var x of resultSet))
 ```
 
 #### `find()` — Returns one item (no `.toList()` needed)
@@ -712,13 +713,18 @@ res = client.call_view("MyView", {"minAge": 18})
 dotnet run -- --cors "http://localhost:3000,http://example.com"
 
 # Configuration Parameters
-# You can customize limits and database behaviour via command-line switches or in appsettings.json.
-# --memory-limit        : Memory limit percentage (default: 0.4)
-# --bulk-cache-limit    : Bulk store max cache in bytes (default: 52428800)
-# --max-recursion       : Max script recursion depth (default: 100)
-# --query-timeout       : Max query timeout in minutes (default: 10)
-# --queue-poll-seconds  : Background queue poll interval in seconds (default: 1.0)
-dotnet run -- --memory-limit 0.3 --query-timeout 5
+# Database configuration settings are stored in the sysconfig system collection.
+# They are initialized with default values during database creation.
+# Authorized users can update the settings via: db.sysconfig.update(x => true, { queryTimeoutMinutes: 15 });
+# Settings require a server restart to take effect.
+# Direct inserts into sysconfig are blocked.
+#
+# Properties in sysconfig:
+# - memoryLimitPercentage    : Memory limit percentage (default: 0.4)
+# - bulkStoreMaxCacheBytes   : Bulk store max cache in bytes (default: 52428800)
+# - maxRecursionDepth        : Max script recursion depth (default: 100)
+# - queryTimeoutMinutes      : Max query timeout in minutes (default: 10)
+# - queuePollIntervalSeconds : Background queue poll interval in seconds (default: 1.0)
 
 # Bootstrap Refactoring (Clean Code)
 # Program.cs is kept extremely simple. The entire application setup and configuration

--- a/Query/QueryOptimizer.cs
+++ b/Query/QueryOptimizer.cs
@@ -41,5 +41,32 @@ namespace AxarDB.Query
 
             return null;
         }
+
+        public static HashSet<string> ExtractAccessedProperties(JsValue predicate)
+        {
+            var props = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            props.Add("_id"); // Always include ID
+
+            if (predicate == null || !predicate.IsObject())
+                return props;
+
+            string code = predicate.ToString();
+            
+            // Match dot notation: x.prop, item.prop, doc.prop
+            var matches = Regex.Matches(code, @"\b(?:x|item|doc)\.(\w+)\b");
+            foreach (Match match in matches)
+            {
+                props.Add(match.Groups[1].Value);
+            }
+
+            // Match bracket notation: x['prop'], x["prop"]
+            var bracketMatches = Regex.Matches(code, @"\b(?:x|item|doc)\[[""'](\w+)[""']\]");
+            foreach (Match match in bracketMatches)
+            {
+                props.Add(match.Groups[1].Value);
+            }
+
+            return props;
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿![AxarDB Logo](./AxarDBLogo.png)
+![AxarDB Logo](./AxarDBLogo.png)
 
 [![License: Custom](https://img.shields.io/badge/License-Metin_YAKAR-blue.svg)](LICENSE)
 [![Docker](https://img.shields.io/badge/Docker-Ready-2496ED.svg?logo=docker&logoColor=white)](Dockerfile)
@@ -85,22 +85,24 @@ services:
 
 ## ⚙️ Configuration
 
-AxarDB supports rich database configuration settings that can be customized via `appsettings.json` or overridden directly at startup via command-line arguments.
+AxarDB configuration settings are stored inside the database in a dedicated system collection named `sysconfig`. During the initial database setup, this collection is populated automatically with default configuration values. 
+
+To modify settings, authorized users can update the document in the `sysconfig` collection. The new settings will take effect after restarting the database application. Direct insert operations on the `sysconfig` collection are not allowed.
 
 ### Available Settings
 
-| Parameter | Configuration Key | Default Value | Description |
+| Property | Type | Default Value | Description |
 | :--- | :--- | :--- | :--- |
-| `--memory-limit` | `DatabaseSettings:MemoryLimitPercentage` | `0.4` | Caps database memory usage (e.g. `0.3` for 30%). |
-| `--bulk-cache-limit` | `DatabaseSettings:BulkStoreMaxCacheBytes` | `52428800` (50MB) | Maximum size of bulk cache in bytes. |
-| `--max-recursion` | `DatabaseSettings:MaxRecursionDepth` | `100` | Limits recursion depth of script executions. |
-| `--query-timeout` | `DatabaseSettings:QueryTimeoutMinutes` | `10` | Caps runtime query execution time in minutes. |
-| `--queue-poll-seconds` | `DatabaseSettings:QueuePollIntervalSeconds` | `1.0` | Controls polling frequency of the background queue. |
+| `memoryLimitPercentage` | `double` | `0.4` | Caps database memory usage (e.g., `0.3` for 30%). |
+| `bulkStoreMaxCacheBytes` | `long` | `52428800` (50MB) | Maximum size of bulk cache in bytes. |
+| `maxRecursionDepth` | `int` | `100` | Limits recursion depth of script executions. |
+| `queryTimeoutMinutes` | `int` | `10` | Caps runtime query execution time in minutes. |
+| `queuePollIntervalSeconds` | `double` | `1.0` | Controls polling frequency of the background queue. |
 
 ### Configuration Example
-To start the database server with a 30% memory cap and a 5-minute query timeout:
-```bash
-dotnet run -- --memory-limit 0.3 --query-timeout 5
+To change settings via query console (requires server restart to apply):
+```javascript
+db.sysconfig.update(x => true, { queryTimeoutMinutes: 15 });
 ```
 
 ---

--- a/Wrappers/CaseInsensitiveDocumentWrapper.cs
+++ b/Wrappers/CaseInsensitiveDocumentWrapper.cs
@@ -11,8 +11,17 @@ namespace AxarDB.Wrappers
 
         public override bool TryGetMember(GetMemberBinder binder, out object? result)
         {
-            var key = Data.Keys.FirstOrDefault(k => string.Equals(k, binder.Name, System.StringComparison.OrdinalIgnoreCase));
-            if (key != null && Data.TryGetValue(key, out var val))
+            string? matchedKey = null;
+            foreach (var key in Data.Keys)
+            {
+                if (string.Equals(key, binder.Name, System.StringComparison.OrdinalIgnoreCase))
+                {
+                    matchedKey = key;
+                    break;
+                }
+            }
+
+            if (matchedKey != null && Data.TryGetValue(matchedKey, out var val))
             {
                 var unwrapped = Unwrap(val);
                 if (unwrapped is string strVal)
@@ -30,39 +39,60 @@ namespace AxarDB.Wrappers
         public static string TurkishNormalize(string str)
         {
             if (string.IsNullOrEmpty(str)) return string.Empty;
-            var sb = new System.Text.StringBuilder(str.Length);
-            foreach (var c in str)
+
+            bool needsNormalization = false;
+            for (int i = 0; i < str.Length; i++)
             {
+                char c = str[i];
+                if (c == 'I' || c == 'İ' || c == 'ı' || 
+                    c == 'Ö' || c == 'ö' || 
+                    c == 'Ü' || c == 'ü' || 
+                    c == 'Ç' || c == 'ç' || 
+                    c == 'Ş' || c == 'ş' || 
+                    c == 'Ğ' || c == 'ğ' || 
+                    char.IsUpper(c))
+                {
+                    needsNormalization = true;
+                    break;
+                }
+            }
+
+            if (!needsNormalization) return str;
+
+            char[] chars = new char[str.Length];
+            for (int i = 0; i < str.Length; i++)
+            {
+                char c = str[i];
                 if (c == 'I' || c == 'İ' || c == 'ı' || c == 'i')
                 {
-                    sb.Append('i');
+                    chars[i] = 'i';
                 }
                 else if (c == 'Ö' || c == 'ö')
                 {
-                    sb.Append('ö');
+                    chars[i] = 'ö';
                 }
                 else if (c == 'Ü' || c == 'ü')
                 {
-                    sb.Append('ü');
+                    chars[i] = 'ü';
                 }
                 else if (c == 'Ç' || c == 'ç')
                 {
-                    sb.Append('ç');
+                    chars[i] = 'ç';
                 }
                 else if (c == 'Ş' || c == 'ş')
                 {
-                    sb.Append('ş');
+                    chars[i] = 'ş';
                 }
                 else if (c == 'Ğ' || c == 'ğ')
                 {
-                    sb.Append('ğ');
+                    chars[i] = 'ğ';
                 }
                 else
                 {
-                    sb.Append(char.ToLowerInvariant(c));
+                    chars[i] = char.ToLowerInvariant(c);
                 }
             }
-            return sb.ToString();
+            return new string(chars);
         }
     }
 }

--- a/release.md
+++ b/release.md
@@ -1,26 +1,57 @@
-# AxarDB Release Notes — Parameterized Database Configuration & Clean Architecture Refactoring
+# AxarDB Release Notes - System Collection Restrictions & Bulk Query Memory Optimization
 
-This release introduces parameterized runtime configuration management with CLI overrides, and completely reorganizes the bootstrapping layer into modular, clean components following SOLID and DRY principles.
+This release introduces protection against custom `sys`-prefixed collection names, and a major optimization for Bulk collection queries using memory-bounded chunked processing with temporary lightweight indexing.
 
 ---
 
 ## 🌟 New Features & Improvements
 
-### 1. Parameterized Database Settings & CLI Overrides
-- Moved all hardcoded database boundaries, memory limits, and query timeouts into `appsettings.json`.
-- Implemented command-line argument bindings via `ConfigHelper` to easily override settings at startup.
-- Introduced parameter mappings for:
-  - `--memory-limit` (MemoryLimitPercentage)
-  - `--bulk-cache-limit` (BulkStoreMaxCacheBytes)
-  - `--max-recursion` (MaxRecursionDepth)
-  - `--query-timeout` (QueryTimeoutMinutes)
-  - `--queue-poll-seconds` (QueuePollIntervalSeconds)
+### 1. System Collection Name Restrictions
 
-### 2. Clean Architecture & Bootstrapping Simplification
-- **Extreme Program.cs Simplification**: Reduced `Program.cs` into a clean 3-line entry point delegating all start orchestration to `AppBootstrap.Run(args)`.
-- **Modular Middlewares**: Extracted inline middlewares into dedicated, isolated classes:
-  - `GlobalExceptionHandlingMiddleware`: Centralizes error logging and Problem Details responses.
-  - `RequestLoggingMiddleware`: Handles stopwatch profiling, request buffering, and metrics recording.
-  - `BasicAuthenticationMiddleware`: Standardizes API security boundary checks.
-- **Unified Endpoint Routing**: Extracted all API route mapping logic into a reusable `EndpointExtensions.MapDatabaseEndpoints()` method.
-- **DRY Basic Authentication**: Consolidated redundant authentication parsing and decoding logic into `HttpContextExtensions.TryGetBasicCredentials()`.
+- **Reserved Prefix Enforcement**: Users are now blocked from creating, accessing, or inserting into any collection whose name starts with `sys`, unless it is one of the pre-defined system collections (`sysusers`, `sysqueue`, `sysvaults`, `sysconfig`).
+- **Multi-layer Protection**: Restrictions are enforced at three levels:
+  - `db.sysnew` — throws `InvalidOperationException` via `AxarDBBridge.TryGetMember`
+  - `AxarDB("sysnew")` — throws `InvalidOperationException` via `DatabaseEngine` constructor binding
+  - `db.sysnew.insert(...)` — blocked via `CollectionBridge.insert` and `Collection.Insert`
+- **Rationale**: Prevents accidental or malicious creation of collections that shadow internal database infrastructure.
+
+### 2. Bulk Query Memory-Bounded Chunked Processing
+
+- **Problem Solved**: Previously, Bulk (JSONL) collection queries loaded all data into memory at once — unsafe for very large files.
+- **Chunked Iteration**: `BulkStore.QueryChunks` now reads JSONL files line-by-line, accumulating data up to the configured `BulkStoreMaxCacheBytes` limit per chunk, then:
+  1. Builds a **temporary lightweight index** containing only the fields accessed by the predicate.
+  2. Runs the predicate (prediction/filtering) against the temp index.
+  3. For matched entries, loads the full document for the result set.
+  4. Releases chunk memory and advances to the next chunk.
+- **Memory Cleanup**: After each chunk is processed, `GC.Collect(0, GCCollectionMode.Optimized)` is called to reclaim memory promptly.
+
+### 3. Temporary Index Optimization for Bulk Predicates
+
+- **Field Extraction via QueryOptimizer**: `QueryOptimizer.ExtractAccessedProperties(JsValue predicate)` uses regex analysis of the JavaScript predicate code to identify accessed property names (dot notation and bracket notation).
+- **Selective Parsing**: `BulkStore.ParseSelectedProperties` uses `System.Text.Json.JsonDocument` to parse only the required fields from each JSON line, without full deserialization — significantly reducing memory pressure for large collections.
+- **Always includes `_id`**: The `_id` field is always extracted regardless of the predicate.
+
+### 4. Bulk Collection Bridge Refactoring
+
+- Updated `findall`, `find`, `contains`, and `startsWith` in `BulkCollectionBridge` to accept `JsValue` instead of `Func<object, bool>`.
+- `findall()` without a predicate still falls back to the fast cached `GetDocuments()` path — no chunk overhead when not needed.
+- `contains` and `startsWith` now correctly route through `QueryChunks` using the `CaseInsensitiveDocumentWrapper`.
+
+### 5. Documentation Fix
+
+- Corrected misleading documentation in `Docs/llm_ragfile_en.md` regarding `findall()`. The function does NOT produce a runtime error when used without `.toList()`. It returns a `ResultSet` that is fully chainable and iterable.
+
+---
+
+## 🔧 Files Changed
+
+| File | Change |
+|---|---|
+| `Definitions/Collection.cs` | Added sys-prefix validation in `Insert` |
+| `Bridges/CollectionBridge.cs` | Restricted insert on sys-prefixed collections |
+| `Bridges/AxarDBBridge.cs` | Blocked access to reserved sys-prefixed names in `TryGetMember` |
+| `Core/DatabaseEngine.cs` | Blocked `AxarDB("sysnew")` constructor calls |
+| `Query/QueryOptimizer.cs` | Added `ExtractAccessedProperties(JsValue)` method |
+| `Bridges/BulkStore.cs` | Added `QueryChunks`, `ProcessChunk`, `ParseSelectedProperties`, `GetJsonValue` |
+| `Bridges/BulkCollectionBridge.cs` | Refactored `findall`, `find`, `contains`, `startsWith` to use `QueryChunks` |
+| `Docs/llm_ragfile_en.md` | Corrected `findall()` description |

--- a/wwwroot/css/style.css
+++ b/wwwroot/css/style.css
@@ -933,3 +933,22 @@ input[type="checkbox"]:checked::after {
 .history-list .empty-state i {
     opacity: 0.3;
 }
+
+/* Sysconfig Warning Banner */
+.sysconfig-banner {
+    background: rgba(99, 102, 241, 0.08);
+    border: 1px solid rgba(99, 102, 241, 0.2);
+    border-left: 4px solid var(--accent);
+    padding: 0.5rem 1rem;
+    margin: 0.5rem 1rem;
+    border-radius: 4px;
+    font-size: 0.85rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--text-secondary);
+}
+
+.sysconfig-banner strong {
+    color: var(--text-primary);
+}

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -67,6 +67,10 @@
                             Execute (Ctrl+Enter)
                         </button>
                     </div>
+                    <div class="sysconfig-banner">
+                        <i data-lucide="info" style="width: 14px; height: 14px; color: var(--accent); flex-shrink: 0;"></i>
+                        <span>Bilgi: <strong>sysconfig</strong> koleksiyonundaki sistem ayarları değişiklikleri, sunucu yeniden başlatıldığında aktif olacaktır.</span>
+                    </div>
                     <div id="editorContainer" class="editor-container"></div>
                     <div class="resizer-h" id="resizerH"></div>
                 </section>


### PR DESCRIPTION
## 🌟 New Features & Improvements

### 1. System Collection Name Restrictions

- **Reserved Prefix Enforcement**: Users are now blocked from creating, accessing, or inserting into any collection whose name starts with `sys`, unless it is one of the pre-defined system collections (`sysusers`, `sysqueue`, `sysvaults`, `sysconfig`).
- **Multi-layer Protection**: Restrictions are enforced at three levels:
  - `db.sysnew` — throws `InvalidOperationException` via `AxarDBBridge.TryGetMember`
  - `AxarDB("sysnew")` — throws `InvalidOperationException` via `DatabaseEngine` constructor binding
  - `db.sysnew.insert(...)` — blocked via `CollectionBridge.insert` and `Collection.Insert`
- **Rationale**: Prevents accidental or malicious creation of collections that shadow internal database infrastructure.

### 2. Bulk Query Memory-Bounded Chunked Processing

- **Problem Solved**: Previously, Bulk (JSONL) collection queries loaded all data into memory at once — unsafe for very large files.
- **Chunked Iteration**: `BulkStore.QueryChunks` now reads JSONL files line-by-line, accumulating data up to the configured `BulkStoreMaxCacheBytes` limit per chunk, then:
  1. Builds a **temporary lightweight index** containing only the fields accessed by the predicate.
  2. Runs the predicate (prediction/filtering) against the temp index.
  3. For matched entries, loads the full document for the result set.
  4. Releases chunk memory and advances to the next chunk.
- **Memory Cleanup**: After each chunk is processed, `GC.Collect(0, GCCollectionMode.Optimized)` is called to reclaim memory promptly.

### 3. Temporary Index Optimization for Bulk Predicates

- **Field Extraction via QueryOptimizer**: `QueryOptimizer.ExtractAccessedProperties(JsValue predicate)` uses regex analysis of the JavaScript predicate code to identify accessed property names (dot notation and bracket notation).
- **Selective Parsing**: `BulkStore.ParseSelectedProperties` uses `System.Text.Json.JsonDocument` to parse only the required fields from each JSON line, without full deserialization — significantly reducing memory pressure for large collections.
- **Always includes `_id`**: The `_id` field is always extracted regardless of the predicate.

### 4. Bulk Collection Bridge Refactoring

- Updated `findall`, `find`, `contains`, and `startsWith` in `BulkCollectionBridge` to accept `JsValue` instead of `Func<object, bool>`.
- `findall()` without a predicate still falls back to the fast cached `GetDocuments()` path — no chunk overhead when not needed.
- `contains` and `startsWith` now correctly route through `QueryChunks` using the `CaseInsensitiveDocumentWrapper`.

### 5. Documentation Fix

- Corrected misleading documentation in `Docs/llm_ragfile_en.md` regarding `findall()`. The function does NOT produce a runtime error when used without `.toList()`. It returns a `ResultSet` that is fully chainable and iterable.

---

## 🔧 Files Changed

| File | Change |
|---|---|
| `Definitions/Collection.cs` | Added sys-prefix validation in `Insert` |
| `Bridges/CollectionBridge.cs` | Restricted insert on sys-prefixed collections |
| `Bridges/AxarDBBridge.cs` | Blocked access to reserved sys-prefixed names in `TryGetMember` |
| `Core/DatabaseEngine.cs` | Blocked `AxarDB("sysnew")` constructor calls |
| `Query/QueryOptimizer.cs` | Added `ExtractAccessedProperties(JsValue)` method |
| `Bridges/BulkStore.cs` | Added `QueryChunks`, `ProcessChunk`, `ParseSelectedProperties`, `GetJsonValue` |
| `Bridges/BulkCollectionBridge.cs` | Refactored `findall`, `find`, `contains`, `startsWith` to use `QueryChunks` |
| `Docs/llm_ragfile_en.md` | Corrected `findall()` description |
